### PR TITLE
use elapsed macro rather than timing for loop, also allow seconds

### DIFF
--- a/src/TimeIt.jl
+++ b/src/TimeIt.jl
@@ -4,12 +4,12 @@ export @timeit
 
 macro timen(ex, n)
     quote
-        local t0 = time_ns()
+        local total = 0.0
         for i = 1:$(esc(n))
-            local val = $(esc(ex))
+            # already warm
+            total += @elapsed $(esc(ex))
         end
-        local t1 = time_ns()
-        (t1 - t0) / 1.e9
+        total / $(esc(n))
     end
 end
 
@@ -17,22 +17,20 @@ macro timeit(ex)
     quote
         local val = $(esc(ex))  # Warm up
         t = zeros(3)
-        
+
         # Determine number of loops so that total time > 0.1s.
         n = 1
         for i = 0:9
             n = 10^i
             t[1] = @timen $(esc(ex)) n
-            if t[1] > 0.1
-                break
-            end
+            t[1] * n > 0.1 && break
         end
 
         # Two more production runs.
         for i = 2:3
             t[i] = @timen $(esc(ex)) n
         end
-        best = minimum(t) / n
+        best = minimum(t)
 
         # Format to nano-, micro- or milliseconds.
         if best < 1e-6
@@ -41,9 +39,11 @@ macro timeit(ex)
         elseif best < 1e-3
             best *= 1e6
             pre = "\u00b5"
-        else
+        elseif best < 1
             best *= 1e3
             pre = "m"
+        else
+            pre = ""
         end
         @printf "%d loops, best of 3: %4.2f %ss per loop\n" n best pre
     end


### PR DESCRIPTION
This seems like it may be "fairer", though I'm not sure if it is more accurate or not. Thought I should throw it out there.

_There is also printing in seconds (if it takes that long)._
