### PR TITLE
Make compatible with recent Julia versions

### DIFF
--- a/src/TimeIt.jl
+++ b/src/TimeIt.jl
@@ -1,5 +1,7 @@
 module TimeIt
 
+using Printf
+
 export @timeit
 
 macro timen(ex, n)


### PR DESCRIPTION
Adding `using Printf` allowed `@timeit` to work in a notebook with Julia 1.0